### PR TITLE
allow more generous strings

### DIFF
--- a/infix/parser.rkt
+++ b/infix/parser.rkt
@@ -60,7 +60,26 @@
 (define-lex-abbrevs
   [letter     (:or (:/ "a" "z") (:/ #\A #\Z) )]
   [digit      (:/ #\0 #\9)]
-  [string     (:: #\" (:* (:or letter digit #\_ #\?)) #\")]
+  [odigit      (:/ #\0 #\7)]
+  [hdigit      (:or (:/ #\0 #\9) (:/ #\a #\f) (:/ #\A #\F))]
+  [string     (:: #\" (:* (:~ #\" #\\)
+                          (:: #\\ #\\)
+                          (:: #\\ #\")
+                          (:: #\\ #\')
+                          (:: #\\ #\a)
+                          (:: #\\ #\b)
+                          (:: #\\ #\t)
+                          (:: #\\ #\n)
+                          (:: #\\ #\r)
+                          (:: #\\ #\v)
+                          (:: #\\ #\f)
+                          (:: #\\ #\e)
+                          (:: #\\ #\newline)
+                          (:: #\\ (:** 1 3 odigit))
+                          (:: #\\ #\x (:** 1 2 hdigit))
+                          (:: #\\ #\u (:** 1 4 hdigit))
+                          (:: #\\ #\U (:** 1 8 hdigit)))
+                  #\")]
   [identifier (:: letter (:* (:or letter digit #\_ #\?)))])
 
 (define expression-lexer
@@ -92,7 +111,7 @@
    ["<>" 'NOT-EQUAL]
    ["≠" 'NOT-EQUAL]
    [string 
-    (token-STRING (substring lexeme 1 (- (string-length lexeme) 1)))]
+    (token-STRING (read (open-input-string lexeme)))]
    [identifier 
     (token-IDENTIFIER (string->symbol (regexp-replace* #rx"_" lexeme "-")))]
    [(:+ digit) (token-NUMBER (string->number lexeme))]


### PR DESCRIPTION
I was playing with this today and frustrated that strings couldn't have spaces.  Maybe this is not a step in the direction you want to go (eg. maybe you want normal strings with escapes, etc, and merging this will cause something like "\n" to be accepted now but be a different string with a future full string parser.  But at any rate I wanted to have some more string support.  Maybe a good solution if you want normal string parsing (with escapes) in the future, but still want to throw me a bone for now, is to simply add the backslash character to the list of characters not allowed in strings.

Or is there a reason that you want limited string support?

Either way, thanks,
William
