### PR TITLE
fix addition errors when syntax objects lack location info

### DIFF
--- a/infix/main.rkt
+++ b/infix/main.rkt
@@ -59,8 +59,10 @@
        ;(display "stx: ") (display stx) (newline)
        (port-count-lines! ip)
        (let* ([line (syntax-line #'str)]
-              [col  (+ (syntax-column   #'str) offset   )]   ; counts from 0
-              [pos  (+ (syntax-position #'str) offset -1)])  ; counts from 1
+              [col  (and (syntax-column #'str)
+                         (+ (syntax-column   #'str) offset   ))]   ; counts from 0
+              [pos  (and (syntax-position #'str)
+                         (+ (syntax-position #'str) offset -1))])  ; counts from 1
          ;(display (list '$$ line col pos)) (newline)
          ; The string str has the position of the first "
          ; We need to skip this.
@@ -85,7 +87,8 @@
                       ;                  is ignored by datum->syntax
                       (list (syntax-source #'str)
                                         (syntax-line #'str)
-                                        (+ (syntax-column #'str) -1)
+                                        (and (syntax-column #'str)
+                                             (+ (syntax-column #'str) -1))
                                         (syntax-position #'str)
                                         (syntax-span #'str))
                       #'str))

--- a/infix/parser.rkt
+++ b/infix/parser.rkt
@@ -153,9 +153,12 @@
                           ; position and line numbers count from 1                          
                           ; column numbers count from 0
                           (list (if (syntax? o) (syntax-source o) 'missing-in-action--sorry)
-                                (if o (+ (syntax-line o)     (position-line   start-pos)   -1) #f)
-                                (if o (+ (syntax-column o)   (position-offset start-pos)     ) #f)
-                                (if o (+ (syntax-position o) (position-offset start-pos)     ) #f)
+                                (and (syntax? o) (syntax-line o)
+                                     (+ (syntax-line o)     (position-line   start-pos)   -1))
+                                (and (syntax? o) (syntax-column o)
+                                     (+ (syntax-column o)   (position-offset start-pos)     ))
+                                (and (syntax? o) (syntax-position o)
+                                     (+ (syntax-position o) (position-offset start-pos)     ))
                                 ; span:
                                 (- (position-offset end-pos) (position-offset start-pos)))
                           o o))))))
@@ -216,9 +219,12 @@
                     (newline)
                     "internal error in package 'infix' - please file bug report"))
               (list (if (syntax? o) (syntax-source o) 'missing-in-action--sorry)
-                    (if o (+ (syntax-line o)     (position-line start) -1) #f)
-                    (if o (+ (syntax-column o)   (position-offset start))  #f)
-                    (if o (+ (syntax-position o) (position-offset start))  #f)
+                    (and (syntax? o) (syntax-line o)
+                         (+ (syntax-line o)     (position-line start) -1))
+                    (and (syntax? o) (syntax-column o)
+                         (+ (syntax-column o)   (position-offset start)))
+                    (and (syntax? o) (syntax-position o)
+                         (+ (syntax-position o) (position-offset start)))
                     (- (position-offset end)
                        (position-offset start)))))))
    


### PR DESCRIPTION
I was playing with this some more in an interactive context, and it would fail during expansion by trying to do addition with a `#f` received from syntax source location functions.  This fixes it.