### PR TITLE
use #lang racket/base to pull fewer dependencies

### DIFF
--- a/infix/main.rkt
+++ b/infix/main.rkt
@@ -1,4 +1,4 @@
-#lang at-exp racket
+#lang at-exp racket/base
 ;; This is not in the use for the moment.
 (provide $ $quote $quote-syntax #%infix)
 

--- a/infix/parameter.rkt
+++ b/infix/parameter.rkt
@@ -1,7 +1,7 @@
-#lang scheme
+#lang racket/base
 (provide #%infix)
-
-(require scheme/stxparam)
+(require racket/stxparam
+         (for-syntax racket/base))
 (define-syntax-parameter #%infix
   (λ (stx)
     (syntax-case stx ()

--- a/infix/parse-string-lexeme.rkt
+++ b/infix/parse-string-lexeme.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang racket/base
 (provide string-lexeme->string)
 
 ;;; This file provides the function

--- a/infix/parser.rkt
+++ b/infix/parser.rkt
@@ -1,6 +1,8 @@
-#lang racket
+#lang racket/base
 (require "parameter.rkt"
-         "parse-string-lexeme.rkt")
+         "parse-string-lexeme.rkt"
+         (for-syntax racket/base)
+         racket/list)
 
 ;;; NOTES: 
 ;;;   Changes from planet version:  ]] (CDB) Bug fixed


### PR DESCRIPTION
Or perhaps you prefer to use #lang racket for convenience.  But the difference in load times between racket and racket/base is pretty big.