### PR TITLE
Remove bold formatting from Scribble title

### DIFF
--- a/infix/scribblings/infix-manual.scrbl
+++ b/infix/scribblings/infix-manual.scrbl
@@ -8,7 +8,7 @@
            infix)
           "util.rkt")
 
-@title[#:tag "top"]{@bold{Infix Expressions} for Racket}
+@title[#:tag "top"]{Infix Expressions for Racket}
 @author[(author+email "Jens Axel Søgaard" "jensaxel@soegaard.net")]
 
 @defmodule[infix]{


### PR DESCRIPTION
For visual consistency with other packages within the docs